### PR TITLE
Always install the latest version of Camilla Proxy

### DIFF
--- a/camilla/install.sls
+++ b/camilla/install.sls
@@ -2,4 +2,3 @@ camilla:
   pkg.installed:
     - name: camilla
     - refresh: True
-    - skip_verify: True

--- a/camilla/repo.sls
+++ b/camilla/repo.sls
@@ -3,6 +3,7 @@ camilla-repo:
     - humanname: Camilla Proxy repository
     - name: deb http://apt.camillaproxy.com/ trusty main
     - file: /etc/apt/sources.list.d/camilla-proxy.list
-    - gpgcheck: 0
+    - gpgcheck: 1
+    - key_url: http://apt.camillaproxy.com/camillaproxy.gpg.key
     - require_in:
       - pkg: camilla

--- a/camilla/service.sls
+++ b/camilla/service.sls
@@ -1,4 +1,4 @@
-# Ensure that Logstash is running
+# Ensure that Camilla Proxy is running
 extend:
   camilla:
     service.running:

--- a/example.pillar
+++ b/example.pillar
@@ -1,1 +1,3 @@
 # Intentionally left blank: no configuration is supported currently.
+camilla:
+  version: latest


### PR DESCRIPTION
Since Camilla Proxy updates quite often at the moment, always explicitly fetching the latest version is a good default at the moment.
Also the package signature is checked when this PR is merged.